### PR TITLE
Refactor car-racing env to use pygame

### DIFF
--- a/gym/envs/box2d/car_dynamics.py
+++ b/gym/envs/box2d/car_dynamics.py
@@ -10,6 +10,7 @@ Created by Oleg Klimov
 import numpy as np
 import math
 import Box2D
+import pygame.draw
 from Box2D.b2 import (
     edgeShape,
     circleShape,
@@ -42,9 +43,12 @@ HULL_POLY3 = [
     (-25, +20),
 ]
 HULL_POLY4 = [(-50, -120), (+50, -120), (+50, -90), (-50, -90)]
-WHEEL_COLOR = (0.0, 0.0, 0.0)
-WHEEL_WHITE = (0.3, 0.3, 0.3)
-MUD_COLOR = (0.4, 0.4, 0.0)
+WHEEL_COLOR = (0, 0, 0)
+WHEEL_WHITE = (77, 77, 77)
+MUD_COLOR = (102, 102, 0)
+
+SCALE = 6.0  # Track scale
+PLAYFIELD = 2000 / SCALE  # Game over boundary
 
 
 class Car:
@@ -260,15 +264,36 @@ class Car:
                 True,
             )
 
-    def draw(self, viewer, draw_particles=True):
+    def draw(self, surface, zoom, translation, draw_particles=True):
         if draw_particles:
             for p in self.particles:
-                viewer.draw_polyline(p.poly, color=p.color, linewidth=5)
+                poly = [
+                    (
+                        (coords[0] + PLAYFIELD) * zoom + translation[0],
+                        (coords[1] + PLAYFIELD) * zoom + translation[1],
+                    )
+                    for coords in p.poly
+                ]
+                pygame.draw.lines(
+                    surface, color=p.color, points=poly, width=2, closed=False
+                )
+
         for obj in self.drawlist:
             for f in obj.fixtures:
                 trans = f.body.transform
                 path = [trans * v for v in f.shape.vertices]
-                viewer.draw_polygon(path, color=obj.color)
+
+                path = [
+                    (
+                        (coords[0] + PLAYFIELD) * zoom + translation[0],
+                        (coords[1] + PLAYFIELD) * zoom + translation[1],
+                    )
+                    for coords in path
+                ]
+                color = [int(c * 255) for c in obj.color]
+
+                pygame.draw.polygon(surface, color=color, points=path)
+
                 if "phase" not in obj.__dict__:
                     continue
                 a1 = obj.phase
@@ -289,7 +314,15 @@ class Car:
                     (+WHEEL_W * SIZE, +WHEEL_R * c2 * SIZE),
                     (-WHEEL_W * SIZE, +WHEEL_R * c2 * SIZE),
                 ]
-                viewer.draw_polygon([trans * v for v in white_poly], color=WHEEL_WHITE)
+                white_poly = [trans * v for v in white_poly]
+                white_poly = [
+                    (
+                        (coords[0] + PLAYFIELD) * zoom + translation[0],
+                        (coords[1] + PLAYFIELD) * zoom + translation[1],
+                    )
+                    for coords in white_poly
+                ]
+                pygame.draw.polygon(surface, color=WHEEL_WHITE, points=white_poly)
 
     def _create_particle(self, point1, point2, grass):
         class Particle:


### PR DESCRIPTION
This PR refactors the rendering function of the two environments to use pygame instead of pyglet. The refactored rendering is consistent with the previous pyglet rendering.

Here is a side by side comparison of the two environments. Left is the old pyglet version, and right is the new pygame version
![car-racing-1](https://user-images.githubusercontent.com/25740538/150978040-f92b3abb-ea26-4370-b15d-14a1fc9c8a40.png)
![car-racing-2](https://user-images.githubusercontent.com/25740538/150978052-ea0b4684-0a41-491d-9384-d92fbc02ccf9.png)
.